### PR TITLE
Adding buzzer support

### DIFF
--- a/Sous_Viduino.ino
+++ b/Sous_Viduino.ino
@@ -37,7 +37,7 @@
 #define ONE_WIRE_GND 4
 
 // Notification pins
-#define BUZZER 7
+#define BUZZER 9
 
 // ************************************************
 // PID Variables and constants


### PR DESCRIPTION
I thought that since Sous Vide takes a long time, a buzzer would be a good method of notifying the user of temperature fluctuations even if you are not in the room.
This provides the functions `setBuzzer()` and `buzzer(int state)`, and a state variable `buzzerState` as a handle for other functions.
By default, the high alarm is 10 degrees over where it should be, and the low alarm is 25 degrees under.
Set the alarm to taste.
The alarm should be pin `D9`.
