### PR TITLE
Bugfix for serial port logging.

### DIFF
--- a/Sous_Viduino.ino
+++ b/Sous_Viduino.ino
@@ -547,6 +547,7 @@ void Run()
       // periodically log to serial port in csv format
       if (millis() - lastLogTime > logInterval)  
       {
+        lastLogTime = millis();
         Serial.print(Input);
         Serial.print(",");
         Serial.println(Output);


### PR DESCRIPTION
#3 
Updating the `lastLogTime` variable every time we log. 