### PR TITLE
Allow to use as thermometer in OFF mode

### DIFF
--- a/Sous_Viduino.ino
+++ b/Sous_Viduino.ino
@@ -243,19 +243,26 @@ void loop()
 void Off()
 {
    myPID.SetMode(MANUAL);
-   lcd.setBacklight(0);
+   lcd.setBacklight(VIOLET);
+   // Now we read even in OFF mode
+   sensors.requestTemperatures(); // Start an asynchronous temperature reading
    digitalWrite(RelayPin, LOW);  // make sure it is off
-   lcd.print(F("    Adafruit"));
+   lcd.print(F("Adafruit - TempC"));
    lcd.setCursor(0, 1);
-   lcd.print(F("   Sous Vide!"));
+   lcd.print(F("Sous Vide-"));
    uint8_t buttons = 0;
    
    while(!(buttons & (BUTTON_RIGHT)))
    {
       buttons = ReadButtons();
+      DoControl();
+
+      lcd.setCursor(10, 1);
+      lcd.print(Input);
+      lcd.write(1);
+      lcd.print(F("C : "));
+      delay(200);
    }
-   // Prepare to transition to the RUN state
-   sensors.requestTemperatures(); // Start an asynchronous temperature reading
 
    //turn the PID on
    myPID.SetMode(AUTOMATIC);


### PR DESCRIPTION
This small patch allows to use the Sous Viduino controller, as a high quality thermomether for the kitchen, even if the device is on OFF mode. This makes it even more valuable as a kitchen tool, specially if like mine, it's screwed to the wall as I use it all the time.
I'm a but reluctant because of the small screen it's a bit tight and I didn't want to remove the "Adafuit", "Sous Viduino!" text. (Fan of Adafruit <3)
I'll welcome any suggestions to make it look nices.